### PR TITLE
small changes on styling of project home page

### DIFF
--- a/source/assets/scripts/ProjectCard.js
+++ b/source/assets/scripts/ProjectCard.js
@@ -60,22 +60,29 @@ class ProjectCard extends HTMLElement {
         margin: 0% 5% 10%;
       }
   
-      /* Style the drag button */
-      button.drag-btn {
+      /* Style the drag button container */
+      .drag-btn-container {
+        /* Use absolute position to place the button container correctly */
         position: absolute;
-        display: flex;
-        background: none;
-        top: 5%;
-        right: 5%;
-        color: inherit;
-        font: inherit;
-        cursor: pointer;
-        padding: 0;
-        border-radius: 5px;
+        top: 10px;
+        right: 10px;
+        width: 2vw;
+        height: auto;
       }
-  
-      button.drag-btn:hover {
-        background-color: grey;
+
+      /* Style the drag buttons within each journal entry */
+      .drag-btn {
+        cursor: grab;
+        background-color: inherit;
+        appearance: none;
+        border: none;
+      }
+
+      /* Style the drag button image */
+      .drag-btn-img {
+        position: relative;
+        width: 100%;
+        height: auto;
       }
   
       /* Style the tags of each project */
@@ -132,7 +139,11 @@ class ProjectCard extends HTMLElement {
     const truncatedDescription = words.length > maxWords ? words.slice(0, maxWords).join(' ') + '...' : data.projectDescription
 
     article.innerHTML = `
-    <button class="drag-btn" onclick="dragProject()">...</button>
+    <div class="drag-btn-container" bis_skin_checked="1">
+      <button class="drag-btn" onclick="dragProject()">
+        <img src="source/assets/images/drag-button.png" alt="drag-btn" class="drag-btn-img">
+      </button>
+    </div>
 
     <h3 class="project-name">${data.projectName}</h3>
 

--- a/source/assets/styles/project_styles.css
+++ b/source/assets/styles/project_styles.css
@@ -63,8 +63,6 @@ header {
 /* Style the main body */
 main {
   display: flex;
-  margin-left: 10%;
-  margin-right: 10%;
   margin: center;
   padding: center;
   margin-top: 5%;
@@ -73,6 +71,7 @@ main {
 
 /* Style the user profile */
 .profile {
+  margin-left: 10%;
   width: auto;
   height: auto;
 }

--- a/source/assets/styles/project_styles.css
+++ b/source/assets/styles/project_styles.css
@@ -9,21 +9,29 @@ body {
   font-style: normal;
   width: 100%;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 60px;
 }
 
 /* Style the header section */
 header {
-  width: auto;
+  width: 100%;
   height: 75px;
   margin-left: auto;
   margin-right: auto;
-  padding-left: 10%;
-  padding-right: 10%;
   padding-bottom: 10px;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
+  position: relative;
   border-bottom: 1px solid #ccc;
+}
+
+/* Style the codelog picture */
+#codelog-pic {
+  padding-left: 10%;
 }
 
 /* Style the CodeLog title */
@@ -36,7 +44,7 @@ header {
 /* Style the menu buttons in the header section */
 .but {
   margin-left: auto;
-  margin-right: 5%;
+  padding-right: 15%;
   display: flex;
   gap: 100px;
 }
@@ -57,7 +65,10 @@ main {
   display: flex;
   margin-left: 10%;
   margin-right: 10%;
+  margin: center;
+  padding: center;
   margin-top: 5%;
+  width: auto;
 }
 
 /* Style the user profile */
@@ -165,11 +176,14 @@ main {
 }
 
 /* Style the copyright footer */
-#footer {
-  padding-top: 25%;
-  margin-left: 10%;
-  font-size: 14px;
+footer {
+  position: relative;
   bottom: 0;
-  width: 100%;
-  height: 60px;
+  left: 0;
+  width: 10%;
+  margin: center;
+  padding-top: 5%;
+  padding-right: 73%;
+  text-align: left;
+  font-size: 14px;
 }

--- a/source/reference/cardTemplate.html
+++ b/source/reference/cardTemplate.html
@@ -4,7 +4,11 @@
 <article class="project">
     <!--The drag button to reorder the projects-->
     <!--Need to implement JS function drag_project()-->
-    <button class="drag-btn" onclick="dragProject()">...</button>
+    <div class="drag-btn-container" bis_skin_checked="1">
+        <button class="drag-btn" onclick="dragProject()">
+          <img src="source/assets/images/drag-button.png" alt="drag-btn" class="drag-btn-img">
+        </button>
+    </div>
 
     <!--Project details-->
     <!--Delete this after implementing "importing project details" function-->
@@ -70,22 +74,29 @@
         margin: 0% 5% 10%;
       }
   
-      /* Style the drag button */
-      button.drag-btn {
+      /* Style the drag button container */
+      .drag-btn-container {
+        /* Use absolute position to place the button container correctly */
         position: absolute;
-        display: flex;
-        background: none;
-        top: 5%;
-        right: 5%;
-        color: inherit;
-        font: inherit;
-        cursor: pointer;
-        padding: 0;
-        border-radius: 5px;
+        top: 10px;
+        right: 10px;
+        width: 2vw;
+        height: auto;
       }
-  
-      button.drag-btn:hover {
-        background-color: grey;
+
+      /* Style the drag buttons within each journal entry */
+      .drag-btn {
+        cursor: grab;
+        background-color: inherit;
+        appearance: none;
+        border: none;
+      }
+
+      /* Style the drag button image */
+      .drag-btn-img {
+        position: relative;
+        width: 100%;
+        height: auto;
       }
   
       /* Style the tags of each project */


### PR DESCRIPTION
Changes:
- centering the `<body>` instead add margin and padding on the body so that when zoom in or zoom out the page the elements stay in the center (except for the header and footer)
- modified the `drag-button` of the project box in **ProjectCard.js** and **CardTemplate.html** according to the **selected_project_page.html**
- need help on always displaying the footer under the profile when zoom in/ out
- the margin/ padding of the header might not be exact. Probably need helps on this as well
<img width="1440" alt="Screenshot 2024-05-25 at 00 41 21" src="https://github.com/cse110-sp24-group27/cse110-sp24-group27/assets/146874935/286b6993-3d7d-4fa8-b770-952849183fb6">


