### PR TITLE
Updated dragging and dropping journal entries in the project page

### DIFF
--- a/source/assets/scripts/selected_project_page.js
+++ b/source/assets/scripts/selected_project_page.js
@@ -44,42 +44,236 @@ function loadTableOfContents () {
 }
 
 // On load of script, load table of contents
-loadTableOfContents()
+// loadTableOfContents()
 
 // Drag Button By Devan //
-// TODO: change to only drag and drop if using the button
-/**
- * @param event reference to the entry being grabbed.
- */
-// function dragProject (event) {
-//   event.dataTransfer.setData('text', event.target.id)
-// }
+// Variables used in dragging and dropping functions
+let listContainer
+let draggableItem
+let pointerStartX
+let pointerStartY
+let items = []
 
 /**
- * @param event reference to the entry to be dragged and dropped.
+ * Sets up the journal entries for dragging and dropping
  */
-// function allowDrop (event) {
-//   event.preventDefault()
-// }
+function dragAndDropSetup () {
+  listContainer = document.getElementById('journal-entries')
+  if (!listContainer) return
+  listContainer.addEventListener('mousedown', dragStart)
+  document.addEventListener('mouseup', dragEnd)
+}
 
-// TODO: add comments for JSDoc
-// Swap Projects
-// function dropProject (event) {
-//   event.preventDefault()
-//   let dragIndex = 0
-//   const clone = event.target.cloneNode(true)
-//   const data = event.dataTransfer.getData('text')
-//   if (clone.id !== data) {
-//     const nodeList = document.getElementById('journal-entries').childNodes
-//     for (let i = 0; i < nodeList.length; i++) {
-//       if (nodeList[i].id === data) {
-//         dragIndex = i
-//       }
-//     }
-//     document.getElementById('journal-entries').replaceChild(document.getElementById(data), event.target)
-//     document.getElementById('journal-entries').insertBefore(clone, document.getElementById('journal-entries').childNodes[dragIndex])
-//   }
-// }
+/**
+ * Initializes everything needed for dragging and dropping
+ * @param e Reference to the mouse click event for dragging
+ */
+function dragStart (e) {
+  if (e.target.classList.contains('drag-btn-img')) {
+    draggableItem = e.target.closest('.journal-entry')
+  }
+  if (!draggableItem) return
+
+  pointerStartX = e.clientX
+  pointerStartY = e.clientY
+  initDraggableItem()
+  initItemsState()
+  document.addEventListener('mousemove', drag)
+}
+
+/**
+ * Updates journal entry positions while dragging
+ * @param e Reference to the mouse click event for dragging
+ */
+function drag (e) {
+  if (!draggableItem) return
+
+  const currentPositionX = e.clientX
+  const currentPositionY = e.clientY
+  const pointerOffsetX = currentPositionX - pointerStartX
+  const pointerOffsetY = currentPositionY - pointerStartY
+  draggableItem.style.transform = `translate(${pointerOffsetX}px, ${pointerOffsetY}px)`
+
+  updateIdleItemsStateAndPosition()
+}
+
+/**
+ * Finalizes and cleans up everything after dropping a journal entry
+ */
+function dragEnd () {
+  if (!draggableItem) return
+
+  applyNewItemsOrder()
+  cleanup()
+}
+
+// Helper functions
+/**
+ * Helper function for dragging and dropping. Gets all entries in the journal entry section
+ */
+function getAllItems () {
+  if (!items?.length) {
+    items = Array.from(listContainer.querySelectorAll('.journal-entry'))
+  }
+  return items
+}
+
+/**
+ * Helper function for dragging and dropping. Gets all entries in the journal entry section 
+ * that aren't being dragged
+ */
+function getIdleItems () {
+  return getAllItems().filter((item) => item.classList.contains('is-idle'))
+}
+
+/**
+ * Helper function for dragging and dropping. Checks whether an entry was above the 
+ * entry currently being dragged in their original positions
+ * @param item Entry to check (not the entry being dragged)
+ * @return Whether the entry was above the entry being dragged
+ */
+function isItemAbove(item) {
+  return item.hasAttribute('data-is-above')
+}
+
+/**
+ * Helper function for dragging and dropping. Checks whether an entry that was 
+ * originally above the entry currently being dragged is now below that entry as a 
+ * result of the dragging
+ * @param item Entry to check (not the entry being dragged)
+ * @returns Whether the entry's relative position to the entry being dragged has changed
+ */
+function isItemToggled(item) {
+  return item.hasAttribute('data-is-toggled')
+}
+
+/**
+ * Helper function for dragStart(). Updates class of the entry being dragged
+ */
+function initDraggableItem () {
+  draggableItem.classList.remove('is-idle')
+  draggableItem.classList.add('is-draggable')
+}
+
+/**
+ * Helper function for dragStart(). Categorizes entries based on whether they are above 
+ * the entry currently being dragged
+ */
+function initItemsState () {
+  getIdleItems().forEach((item, i) => {
+    if (getAllItems().indexOf(draggableItem) > i) {
+      item.dataset.isAbove = ''
+    }
+  })
+}
+
+/**
+ * Helper function for drag(). Continuously updates the entries not being dragged 
+ * while an entry is being dragged
+ */
+function updateIdleItemsStateAndPosition () {
+  const draggableItemRect = draggableItem.getBoundingClientRect()
+  const draggableItemY = draggableItemRect.top + draggableItemRect.height / 2
+  const ITEMS_GAP = 40 // This variable should be the same as the down arrow height
+
+  getIdleItems().forEach((item) => {
+    const itemRect = item.getBoundingClientRect()
+    const itemY = itemRect.top + itemRect.height / 2
+    if (isItemAbove(item)) {
+      if (draggableItemY <= itemY) {
+        item.dataset.isToggled = ''
+      } else {
+        delete item.dataset.isToggled
+      }
+    } else {
+      if (draggableItemY >= itemY) {
+        item.dataset.isToggled = ''
+      } else {
+        delete item.dataset.isToggled
+      }
+    }
+  })
+
+  getIdleItems().forEach((item) => {
+    if (isItemToggled(item)) {
+      const direction = isItemAbove(item) ? 1 : -1
+      item.style.transform = `translateY(${
+        direction * (draggableItemRect.height + ITEMS_GAP)
+      }px)`
+    } else {
+      item.style.transform = ''
+    }
+  })
+}
+
+/**
+ * Helper function for dragEnd(). Reorders and reassembles the entries after the 
+ * entry being dragged has been dropped
+ */
+function applyNewItemsOrder () {
+  const reorderedItems = []
+  getAllItems().forEach((item, index) => {
+    if (item === draggableItem) {
+      return
+    }
+    if (!isItemToggled(item)) {
+      reorderedItems[index] = item
+      return
+    }
+    const newIndex = isItemAbove(item) ? index + 1 : index - 1
+    reorderedItems[newIndex] = item
+  })
+
+  for (let index = 0; index < getAllItems().length; index++) {
+    const item = reorderedItems[index]
+    if (typeof item === 'undefined') {
+      reorderedItems[index] = draggableItem
+    }
+  }
+
+  const downArrows = Array.from(document.querySelectorAll('.down-arrow'))
+  reorderedItems.forEach((item) => {
+    listContainer.appendChild(item)
+    if (downArrows.length !== 0) {
+      listContainer.appendChild(downArrows.pop())
+    }
+  })
+}
+
+/**
+ * Helper function for dragEnd(). Resets all entry states after dropping an entry
+ */
+function unsetItemState () {
+  getIdleItems().forEach((item, i) => {
+    delete item.dataset.isAbove
+    delete item.dataset.isToggled
+    item.style.transform = ''
+  })
+}
+
+/**
+ * Helper function for dragEnd(). Resets a dragged entry after it is dropped
+ */
+function unsetDraggableItem () {
+  draggableItem.style = null
+  draggableItem.classList.remove('is-draggable')
+  draggableItem.classList.add('is-idle')
+  draggableItem = null
+}
+
+/**
+ * Helper function for dragEnd(). Resets everything necessary after an entry is 
+ * dropped
+ */
+function cleanup () {
+  items = []
+  unsetDraggableItem()
+  unsetItemState()
+  document.removeEventListener('mousemove', drag)
+}
+
+// On load of script, set up dragging and dropping of journal entries
+dragAndDropSetup()
 
 // Show Popup Button //
 const showButton = document.getElementById('create-btn')
@@ -145,9 +339,9 @@ function createEntry () {
 
 // Attach event listeners to each journal entry (replace with actual selector)
 // This code is temporary, just to see how hovering, single click, and doubleclick might function
-const journalEntries = document.querySelectorAll('.journal-entry')
-journalEntries.forEach(entry => {
-  entry.addEventListener('mouseover', () => console.log('show preview')) // handleJournalEntryHover(entry)
-  entry.addEventListener('click', () => console.log('expand journal entry')) // handleJournalEntryClick(entry)
-  entry.addEventListener('dblclick', () => console.log('edit journal')) // handleJournalEntryDoubleClick(entry)
-})
+// const journalEntries = document.querySelectorAll('.journal-entry')
+// journalEntries.forEach(entry => {
+//   entry.addEventListener('mouseover', () => console.log('show preview')) // handleJournalEntryHover(entry)
+//   entry.addEventListener('click', () => console.log('expand journal entry')) // handleJournalEntryClick(entry)
+//   entry.addEventListener('dblclick', () => console.log('edit journal')) // handleJournalEntryDoubleClick(entry)
+// })

--- a/source/assets/scripts/selected_project_page.js
+++ b/source/assets/scripts/selected_project_page.js
@@ -1,47 +1,47 @@
 // Js for the functionality of the Selected Project Page // (Back button functionality is not here)
 // Table of Contents By Kristhian Ortiz //
-const dynamicContentList = document.getElementById('dynamic-content-list') // Get table of contents' list
-/**
- * Generates a dynamic table of contents.
- */
-function loadTableOfContents () {
-  dynamicContentList.innerHTML = '' // clear contents
+// const dynamicContentList = document.getElementById('dynamic-content-list') // Get table of contents' list
+// /**
+//  * Generates a dynamic table of contents.
+//  */
+// function loadTableOfContents () {
+//   dynamicContentList.innerHTML = '' // clear contents
 
-  // Get all entries from local Storage (we receive a string representing an object)
-  const entriesForListAsString = localStorage.getItem('entries')
-  // Convert the string back into an object using JSON.parse
-  const entriesForList = JSON.parse(entriesForListAsString)
+//   // Get all entries from local Storage (we receive a string representing an object)
+//   const entriesForListAsString = localStorage.getItem('entries')
+//   // Convert the string back into an object using JSON.parse
+//   const entriesForList = JSON.parse(entriesForListAsString)
 
-  /**
-   * Each Entry Object in 'entries' will have:
-   * Entry Name (Journal Title)
-   * id (unique identifier for this entry)
-   * Entry Template
-   * Tags
-   * Markdown File
-   *
-   * We only want the Entry Name (can be accessed using .)
-   */
-  entriesForList.forEach(entry => {
-    // Fetch Project Entries' data
-    const entryTitleName = entry.titleName
-    const entryId = entry.id
+//   /**
+//    * Each Entry Object in 'entries' will have:
+//    * Entry Name (Journal Title)
+//    * id (unique identifier for this entry)
+//    * Entry Template
+//    * Tags
+//    * Markdown File
+//    *
+//    * We only want the Entry Name (can be accessed using .)
+//    */
+//   entriesForList.forEach(entry => {
+//     // Fetch Project Entries' data
+//     const entryTitleName = entry.titleName
+//     const entryId = entry.id
 
-    // Create list item to be included in table of contents.
-    const listContent = document.createElement('ul')
-    // Create an anchor so that it can be linked
-    const anchor = document.createElement('a')
+//     // Create list item to be included in table of contents.
+//     const listContent = document.createElement('ul')
+//     // Create an anchor so that it can be linked
+//     const anchor = document.createElement('a')
 
-    // Link entry in table of contents to actual entry in webpage
-    anchor.href = `#${entryId}` // Link by id
-    anchor.textContent = entryTitleName // String holding the link will be the title
+//     // Link entry in table of contents to actual entry in webpage
+//     anchor.href = `#${entryId}` // Link by id
+//     anchor.textContent = entryTitleName // String holding the link will be the title
 
-    // Add anchor to listContent
-    listContent.appendChild(anchor)
-    // Add listContent to table of content list.
-    dynamicContentList.appendChild(listContent)
-  })
-}
+//     // Add anchor to listContent
+//     listContent.appendChild(anchor)
+//     // Add listContent to table of content list.
+//     dynamicContentList.appendChild(listContent)
+//   })
+// }
 
 // On load of script, load table of contents
 // loadTableOfContents()
@@ -119,7 +119,7 @@ function getAllItems () {
 }
 
 /**
- * Helper function for dragging and dropping. Gets all entries in the journal entry section 
+ * Helper function for dragging and dropping. Gets all entries in the journal entry section
  * that aren't being dragged
  */
 function getIdleItems () {
@@ -127,23 +127,23 @@ function getIdleItems () {
 }
 
 /**
- * Helper function for dragging and dropping. Checks whether an entry was above the 
+ * Helper function for dragging and dropping. Checks whether an entry was above the
  * entry currently being dragged in their original positions
  * @param item Entry to check (not the entry being dragged)
  * @return Whether the entry was above the entry being dragged
  */
-function isItemAbove(item) {
+function isItemAbove (item) {
   return item.hasAttribute('data-is-above')
 }
 
 /**
- * Helper function for dragging and dropping. Checks whether an entry that was 
- * originally above the entry currently being dragged is now below that entry as a 
+ * Helper function for dragging and dropping. Checks whether an entry that was
+ * originally above the entry currently being dragged is now below that entry as a
  * result of the dragging
  * @param item Entry to check (not the entry being dragged)
  * @returns Whether the entry's relative position to the entry being dragged has changed
  */
-function isItemToggled(item) {
+function isItemToggled (item) {
   return item.hasAttribute('data-is-toggled')
 }
 
@@ -156,7 +156,7 @@ function initDraggableItem () {
 }
 
 /**
- * Helper function for dragStart(). Categorizes entries based on whether they are above 
+ * Helper function for dragStart(). Categorizes entries based on whether they are above
  * the entry currently being dragged
  */
 function initItemsState () {
@@ -168,7 +168,7 @@ function initItemsState () {
 }
 
 /**
- * Helper function for drag(). Continuously updates the entries not being dragged 
+ * Helper function for drag(). Continuously updates the entries not being dragged
  * while an entry is being dragged
  */
 function updateIdleItemsStateAndPosition () {
@@ -207,7 +207,7 @@ function updateIdleItemsStateAndPosition () {
 }
 
 /**
- * Helper function for dragEnd(). Reorders and reassembles the entries after the 
+ * Helper function for dragEnd(). Reorders and reassembles the entries after the
  * entry being dragged has been dropped
  */
 function applyNewItemsOrder () {
@@ -262,7 +262,7 @@ function unsetDraggableItem () {
 }
 
 /**
- * Helper function for dragEnd(). Resets everything necessary after an entry is 
+ * Helper function for dragEnd(). Resets everything necessary after an entry is
  * dropped
  */
 function cleanup () {

--- a/source/assets/styles/styles.css
+++ b/source/assets/styles/styles.css
@@ -193,8 +193,8 @@ h2 {
 
 /* Style the down arrow between entries */
 .down-arrow {
-  width: 10%;
-  height: auto;
+  width: auto;
+  height: 40px;
   margin-left: auto;
   margin-right: auto;
   margin-top: -20px;

--- a/source/reference/selected_project_page.html
+++ b/source/reference/selected_project_page.html
@@ -71,8 +71,7 @@
                 <!--Display each journal entry in a box-->
                 <!--Each journal entry has a name, tag(s), and text (could add more parts to entries)-->
                 <!--Journal entries can be added/deleted using a JS function-->
-                <div class="journal-entry" id="entry1-container" draggable="true" ondragstart="dragProject(event)" 
-                ondrop="dropProject(event)" ondragover="allowDrop(event)">
+                <div class="journal-entry is-idle" id="entry1-container">
                     <h2 class="entry-name" id="entry1">Journal entry name</h2>
                     <h4 class="entry-template">Journal entry template</h4>
                     <p class="entry-text">
@@ -96,7 +95,7 @@
                     <!--Drag button to reorder the projects-->
                     <!--Need to implement JS function drag_project()-->
                     <div class="drag-btn-container">
-                        <button class="drag-btn" onclick="dragProject()">
+                        <button class="drag-btn">
                             <img src="../assets/images/drag-button.png" alt="drag-btn" class="drag-btn-img"/>
                         </button>
                     </div>
@@ -111,8 +110,7 @@
                 <!--
                 <img src="../assets/images/down-arrow.png" alt="down-arrow" class="down-arrow" />
 
-                <div class="journal-entry" id="entry2-container" draggable="true" ondragstart="dragProject(event)" 
-                ondrop="dropProject(event)" ondragover="allowDrop(event)">
+                <div class="journal-entry is-idle" id="entry2-container">
                     <h2 class="entry-name" id="entry2">Journal entry name 2</h2>
                     <h4 class="entry-template">Template</h4>
                     <p class="entry-text">
@@ -122,7 +120,7 @@
                         Cras nulla libero, fermentum vitae sem at, efficitur blandit velit.
                     </p>
                     <div class="drag-btn-container">
-                        <button class="drag-btn" onclick="dragProject()">
+                        <button class="drag-btn">
                             <img src="../assets/images/drag-button.png" alt="drag-btn" class="drag-btn-img"/>
                         </button>
                     </div>
@@ -134,8 +132,7 @@
 
                 <img src="../assets/images/down-arrow.png" alt="down-arrow" class="down-arrow" />
 
-                <div class="journal-entry" id="entry3-container" draggable="true" ondragstart="dragProject(event)" 
-                ondrop="dropProject(event)" ondragover="allowDrop(event)">
+                <div class="journal-entry is-idle" id="entry3-container">
                     <h2 class="entry-name" id="entry3">Journal entry name 3</h2>
                     <h4 class="entry-template">Template</h4>
                     <p class="entry-text">
@@ -146,7 +143,7 @@
                         vel elit ut quam tincidunt fringilla. Donec et nulla lectus.
                     </p>
                     <div class="drag-btn-container">
-                        <button class="drag-btn" onclick="dragProject()">
+                        <button class="drag-btn">
                             <img src="../assets/images/drag-button.png" alt="drag-btn" class="drag-btn-img"/>
                         </button>
                     </div>
@@ -218,7 +215,7 @@
         </footer>
         
         <!-- Link to script -->
-        <script defer src="../assets/scripts/+_button_selcted_project_page.js"></script>
-        <script src="../assets/scripts/selected_project_page.js"></script>
+        <script type="text/javascript" src="../assets/scripts/+_button_selcted_project_page.js"></script>
+        <script type="text/javascript" src="../assets/scripts/selected_project_page.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Page status:

https://github.com/cse110-sp24-group27/cse110-sp24-group27/assets/146765754/758d0b57-79e6-4dd2-af96-efab329c7556

Changes:
- Made entries visually move while dragging so that it's clear the user is dragging the entry
- Made entries only able to be dragged via the drag button

Note: Entries currently reset their positions on page reload, but I believe this will be fixed when `localStorage` is implemented. What's happening right now is that the entry positions are actually being updated after the drag-and-drop, but they are being reset to the "hard-coded" ordering in the HTML upon refresh. Once we use `localStorage` to store the entries, there won't be any hard-coded ordering, so the ordering changes will be saved even after refresh. (This is what I think is going on, but I could be wrong.)