### PR TITLE
error fixed by changing element selecting method

### DIFF
--- a/source/assets/scripts/ProjectCard.js
+++ b/source/assets/scripts/ProjectCard.js
@@ -192,11 +192,11 @@ class ProjectCard extends HTMLElement {
 
     const projectNameLink = article.querySelector('.project-name')
 
-    projectNameLink.addEventListener('click', loadProjectNameToLocalStorage())
+    projectNameLink.addEventListener('click', loadProjectNameToLocalStorage)
 
-    function loadProjectNameToLocalStorage () {
-      console.log('title was clicked')
-      const h3Element = projectNameLink.querySelector('h3')
+    function loadProjectNameToLocalStorage (event) {
+      const h3Element = event.target.closest('.project-name')
+      // const h3Element = projectNameLink.querySelector('h3')
       const currDisplayedProject = h3Element.textContent.trim() // Get text content and remove any leading/trailing spaces
       localStorage.setItem('currDisplayedProject', currDisplayedProject)
     }


### PR DESCRIPTION
![image](https://github.com/cse110-sp24-group27/cse110-sp24-group27/assets/75396243/955a2d1e-8123-4368-b4ee-f4091f8291eb)

when we do querySelector('h2'), it'd get all the `<h2>` elements then select the latest one, so it'd always pick the one at the bottom of the list. 
i changed the code to `event.target.closest('.project-name') so it'd pick the one that we click on.

the reason the function works before is that we had `anchorElement`, so it only query `<h2>` within the box. without `anchorElement`, it'd query all the `<h2>` elements in DOM